### PR TITLE
Add support for defining chunked transfer minimum chunk size

### DIFF
--- a/brim/server.py
+++ b/brim/server.py
@@ -515,6 +515,9 @@ class WSGISubserver(IPSubserver):
         self.wsgi_input_iter_chunk_size = conf.get_int(
             self.name, 'wsgi_input_iter_chunk_size',
             conf.get_int('brim', 'wsgi_input_iter_chunk_size', 4096))
+        self.wsgi_output_iter_chunk_size = conf.get_int(
+            self.name, 'wsgi_output_iter_chunk_size',
+            conf.get_int('brim', 'wsgi_output_iter_chunk_size', 4096))
 
         self.apps = []
         app_names = conf.get(self.name, 'apps', '').strip().split()
@@ -647,6 +650,7 @@ class WSGISubserver(IPSubserver):
         pool = GreenPool(size=self.concurrent_per_worker)
         try:
             wsgi.server(self.sock, self._wsgi_entry, _EventletWSGINullLogger(),
+                        minimum_chunk_size=self.wsgi_output_iter_chunk_size,
                         custom_pool=pool)
         except socket_error, err:
             if err.errno != EINVAL:

--- a/brim/test/unit/test_server.py
+++ b/brim/test/unit/test_server.py
@@ -1805,7 +1805,8 @@ class TestWSGISubserver(TestIPSubserver):
         self.assertEquals(pool.size, ss.concurrent_per_worker)
         self.assertEquals(server_calls, [(
             (ss.sock, ss._wsgi_entry, null_logger),
-            {'custom_pool': pool})])
+            {'minimum_chunk_size': 4096,
+             'custom_pool': pool})])
         if raises == 'socket einval':
             self.assertEquals(exc, None)
         elif raises == 'socket other':

--- a/etc/brimd.conf-sample
+++ b/etc/brimd.conf-sample
@@ -77,6 +77,11 @@
 # wsgi_input_iter_chunk_size = <bytes>
 #   The number of bytes read per chunk when the WSGI input is used as an
 #   iterator. This use case isn't very common. Default: 4096
+# wsgi_output_iter_chunk_size = <bytes>
+#   The number of bytes read per chunk when using Transfer-encoding: Chunked and
+#   iterating out a response. Useful to decrease for long polling, short message
+#   connections such as HTML5 Server-Sent Events. Technically in violation of the
+#   WSGI spec but supported by Eventlet. Default: 4096
 
 [wsgi2]
 #   You can have multiple sets of WSGI apps configured by adding additional


### PR DESCRIPTION
Added a small change to allow configurable HTTP chunk size when serving chunked transfer encoded data. Eventlet allows this but seems to default to 4096 byte chunks.

This causes problems with long running requests using a generator which, rather than yielding large chunks of large files, instead generates short intermittent messages such as this EventSource stream.

```
$ curl -D - http://127.0.0.1/events/
HTTP/1.1 200 OK
Date: Sun, 23 Dec 2012 09:33:19 GMT
Content-Type: text/event-stream
Transfer-Encoding: chunked
Connection: keep-alive
Cache-Control: no-cache

data: {"a": 2, "timestamp": 1356255200}

data: {"a": 3, "timestamp": 1356255220}

data: {"a": 5, "timestamp": 1356255225}
```

With the default chunk size these messages will buffer until there is a full chunk to send - resulting in a whole bunch at once. Dropping the minimum chunk size lets these come through as expected.

While my use case does kinda seem like a blatant disregard for the buffering and streaming part of PEP333 it still feels a reasonable/useful parameter in eventlet.wsgi.server to expose and the default setting doesn't change existing behaviour...
